### PR TITLE
Fix: Add Vercel configuration for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+    "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a `vercel.json` configuration file to fix 404 errors when navigating directly to pages other than the home page in the Vercel deployment. The configuration rewrites all routes to the index.html file, which is necessary for single-page applications (SPAs) that use client-side routing.

Fixes # (issue related to 404 errors in Vercel deployment)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Validated the configuration with `npm run validate`
- Checked the code with `npm run check`
- Built the application with `npm run build`
- All commands completed successfully

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

This is a common configuration for SPAs deployed on Vercel. Without this configuration, users who navigate directly to a URL (not through the app) or refresh a page would get a 404 error because Vercel would try to find a file at that path instead of serving the index.html file and letting the client-side router handle the routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented an enhanced routing configuration that ensures seamless client-side navigation across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->