### PR TITLE
Fix Vercel build by enabling devDependencies installation

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,5 +11,5 @@
             "maxDuration": 10
         }
     },
-    "installCommand": "npm install"
+    "installCommand": "npm install --production=false"
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes the Vercel build issue by ensuring that devDependencies are properly installed during the build process. The current build is failing because Vercel's default behavior is to skip devDependencies installation, but our project requires these dependencies for the build process to complete successfully.

The fix involves updating the `vercel.json` configuration to explicitly set `installCommand` to `npm install --production=false`, which ensures all dependencies, including devDependencies, are installed during the build process.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The changes have been tested by:
1. Running `npm run validate` locally to ensure all linting and type checking passes
2. Running `npm run build` locally to verify the build process completes successfully
3. Verifying that the updated configuration correctly instructs Vercel to install devDependencies

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (updated changes file)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional context

This fix addresses a common issue with Vercel deployments in monorepo setups where devDependencies are required for the build process. By explicitly setting the installCommand, we ensure that all necessary dependencies are available during the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the installation process configuration to include development dependencies, ensuring a comprehensive setup during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->